### PR TITLE
Changed ProteinDB.query() to immediately return result

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ from proteindb import ProteinDB
 >> db.populate('uniprot1.fasta')
 
 >> db.query(uniprot_id='DFAFDA1')
->> db.result
 'SDFYUONNAJDMAMDFHAABWQ'
 
 >> db.query(sequence='SDFYUONNAJDMAMDFHAABWQ')
->> db.result
 'DFAFDA1'
 ```  

--- a/proteindb/proteindb.py
+++ b/proteindb/proteindb.py
@@ -20,7 +20,6 @@ def setup_db(filename):
 class ProteinDB:
     def __init__(self, filename='protein.db'):
         self._conn = setup_db(filename)
-        self.result = None
 
     def populate(self, fasta_filename):
         cursor = self._conn.cursor()
@@ -47,4 +46,5 @@ class ProteinDB:
 
         assert len(results[0]) == 1
         assert len(results) == 1
-        self.result = results[0][0]
+        result = results[0][0]
+        return result

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -77,19 +77,17 @@ def test_db_contains_correct_records(populated_db, fasta_records):
 
 
 def test_querying_uniprot_id_works(populated_db, fasta_records):
-    assert not populated_db.result
 
     for record in fasta_records:
         sequence = str(record.seq)
         uniprot_id = str(record.id.split('|')[1])
-        populated_db.query(uniprot_id=uniprot_id)
-        assert populated_db.result == sequence
+        result = populated_db.query(uniprot_id=uniprot_id)
+        assert result == sequence
 
 def test_querying_sequence_works(populated_db, fasta_records):
-    assert not populated_db.result
 
     for record in fasta_records:
         sequence = str(record.seq)
         uniprot_id = str(record.id.split('|')[1])
-        populated_db.query(sequence=sequence)
-        assert populated_db.result == uniprot_id
+        result = populated_db.query(sequence=sequence)
+        assert result == uniprot_id

--- a/tests/test_protein_database.py
+++ b/tests/test_protein_database.py
@@ -1,10 +1,18 @@
+import pytest
 from pytest_bdd import scenario, given, when, then, scenarios
 from proteindb import ProteinDB
 from os import path
 
+
+@pytest.fixture
+def Workspace():
+    """A singleton object representing the variables in memory in a session."""
+    class Workspace:
+        pass
+    return Workspace
+
 @given("I have a database populated with data from Fasta file named <filename>.")
 def db(filename):
-
     db = ProteinDB()
     db.populate(path.join('data', filename))
     return db
@@ -22,13 +30,13 @@ def uniprot_id(uniprot_id):
 
 
 @when("I search for <uniprot_id> in a database")
-def step_impl(db, uniprot_id):
-    db.query(uniprot_id=uniprot_id)
+def step_impl(db, uniprot_id, Workspace):
+    Workspace.result = db.query(uniprot_id=uniprot_id)
 
 
 @then("I will see the corresponding <sequence>")
-def step_impl(db, sequence):
-    assert db.result == sequence
+def step_impl(Workspace, sequence):
+    assert Workspace.result == sequence
 
 
 #############
@@ -43,11 +51,11 @@ def sequence(sequence):
 
 
 @when("I search for the <sequence> in the database")
-def step_impl(db, sequence):
-    db.query(sequence=sequence)
+def step_impl(db, sequence, Workspace):
+    Workspace.result = db.query(sequence=sequence)
 
 
 @then("I will see the corresponding <uniprot_id>")
-def step_impl(db, uniprot_id):
-    assert db.result == uniprot_id
+def step_impl(uniprot_id, Workspace):
+    assert Workspace.result == uniprot_id
 


### PR DESCRIPTION
Doing BDD was really productive, but i wasn't happy with how the test framework pushed us to use mutable objects (like Browser) in order to split a single test into multiple functions.  It pushed us to use certain designs for our functions, and is what really made us go with an object-oriented design for the package.  In my opinion, this is not good; while tests should help us design maintainable code, it should not push for a specific style of code.  

However, there *is* a mutable aspect to working with immutable functions that we can exploit in our acceptance tests: the names in the user's workspace during a Python session.  With this commit, I use a new class fixture, "Workspace", as the "Browser" stand-in.  It's just a blank class that we can attach variables to, and because Pytest re-creates it for each test, it doesn't have to be managed in any complex way.  With this approach, I was able to remove the ProteinDB.result attribute and change the ProteinDB.query() method to immediately return the result.  

Besides being a cleaner approach, I think this shows that we can use pytest-bdd for any kind of code project we wish to use in the future.

Best wishes,

Nick